### PR TITLE
Added Instagram Post Functionality (Need Client's Instagram)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This application will be a landing page and introductory page for a gaming appli
 npm install react-burger-menu --save
 
 npm install --save react-twitter-embed
+
+npm i react-instagram-embed
 ## Available Scripts
 
 In the project directory, you can run:

--- a/client/src/views/Blog/Blog.js
+++ b/client/src/views/Blog/Blog.js
@@ -18,7 +18,7 @@ function Blog() {
                 options={{ height: 500, width: 500 }}
             /> 
 			<InstagramEmbed
-			  url='https://www.instagram.com/elonmusk/?hl=en'
+			  url='https://www.instagr.am/p/B4S2p2vBE5L'
 			  maxWidth={500}
 			  hideCaption={false}
 			  containerTagName='div'

--- a/client/src/views/Blog/Blog.js
+++ b/client/src/views/Blog/Blog.js
@@ -2,7 +2,7 @@ import React from 'react';
 import logo from '../../assets/OrchardGroveLogo.png';
 import './Blog.css';
 import { TwitterTimelineEmbed } from 'react-twitter-embed';
-
+import InstagramEmbed from 'react-instagram-embed';
 
 function Blog() {
     return (
@@ -17,6 +17,18 @@ function Blog() {
                 screenName="elonmusk"
                 options={{ height: 500, width: 500 }}
             /> 
+			<InstagramEmbed
+			  url='https://www.instagram.com/elonmusk/?hl=en'
+			  maxWidth={500}
+			  hideCaption={false}
+			  containerTagName='div'
+			  protocol=''
+			  injectScript
+			  onLoading={() => {}}
+			  onSuccess={() => {}}
+			  onAfterRender={() => {}}
+			  onFailure={() => {}}
+			/>
         </div>
     );
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "concurrently \"nodemon server/server.js\" \"cd client && npm run start\"",
     "build": "cd client && npm build",
     "start": "node server/server.js",
-    "heroku-postbuild": "cd client && npm install && npm install --only=dev --no-shrinkwrap && npm install --save react-twitter-embed && npm run build"
+    "heroku-postbuild": "cd client && npm install && npm install --only=dev --no-shrinkwrap && npm install --save react-twitter-embed && npm i react-instagram-embed && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two possible issues with this. 
1) I can only seem to get single posts to show up, which is fine if we ask the client to make a "forward growth" post and we link it as a "check us out on instagram" thing as it does have a link to the instagram page.
2) Apparently Instagram is completely revamping their API right now, so there's a non-zero chance this will break by the end of 2020.
